### PR TITLE
Added support for MySQL databases using spatial extensions

### DIFF
--- a/mysql2psql
+++ b/mysql2psql
@@ -203,7 +203,14 @@ class MysqlReader
  
     def query_for_pager
       query = has_id? ? 'WHERE id >= ? AND id < ?' : 'LIMIT ?,?'
-      "SELECT #{columns.map{|c| "`"+c[:name]+"`"}.join(", ")} FROM `#{name}` #{query}"
+      cols = columns.map do |c|
+        if "multipolygon" == c[:type]
+          "AsWKT(`#{c[:name]}`) as `#{c[:name]}`"
+        else
+          "`#{c[:name]}`"
+        end
+      end
+      "SELECT #{cols.join(", ")} FROM `#{name}` #{query}"
     end
   end
   
@@ -345,6 +352,8 @@ class PostgresWriter < Writer
       enum = column[:type].gsub(/enum|\(|\)/, '')
       max_enum_size = enum.split(',').map{ |check| check.size() -2}.sort[-1]
       "character varying(#{max_enum_size}) check( #{column[:name]} in (#{enum}))"
+    when "multipolygon"
+      "geometry"
     else
       puts "Unknown #{column.inspect}"
       column[:type].inspect


### PR DESCRIPTION
I'm migrating a database that uses MySQL's spatial extensions and I needed mysql2postgres to support MySQL multipolygon columns. This change creates these columns as PostgreSQL/PostGIS geometry columns and dumps the MySQL data using AsWKT that can then be pushed into PostgreSQL.

Other spatial types could be supported using a similar approach, but I didn't need anything other than multipolygons.