### PR TITLE
Two small changes, quote check constraints and handle mysql "sets"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 configs
 test/fixtures/test*.sql
 pkg
+*~

--- a/lib/mysql2psql/mysql_reader.rb
+++ b/lib/mysql2psql/mysql_reader.rb
@@ -47,6 +47,8 @@ class Mysql2psql
           "decimal"
         when /double/
            "double precision"
+        when /set/
+           "varchar"
         else
           type
         end 

--- a/lib/mysql2psql/postgres_writer.rb
+++ b/lib/mysql2psql/postgres_writer.rb
@@ -98,7 +98,7 @@ class Mysql2psql
         default = default + "::character varying" if default
         enum = column[:type].gsub(/enum|\(|\)/, '')
         max_enum_size = enum.split(',').map{ |check| check.size() -2}.sort[-1]
-        "character varying(#{max_enum_size}) check( #{column[:name]} in (#{enum}))"
+        "character varying(#{max_enum_size}) check( \"#{column[:name]}\" in (#{enum}))"
       else
         puts "Unknown #{column.inspect}"
         column[:type].inspect


### PR DESCRIPTION
Thanks for the great software.  I made two very small changes.  The first handles mysql sets as simple varchar, so the data are loaded as comma-separated strings.  A more rigorous handling would load them as an array, but I'll save that for another dat.  A second change is to quote the column name in check constraints (from mysql enums) as they are written to postgres.  I had several mysql enum columns with odd capitalization on which this was failing.
