### PR TITLE
Forcing file encoding to be utf-8.

### DIFF
--- a/lib/mysql2psql/postgres_db_writer.rb
+++ b/lib/mysql2psql/postgres_db_writer.rb
@@ -19,7 +19,7 @@ class Mysql2psql
     
     def inload
   
-      File.open(filename, 'r') do |file|
+      File.open(filename, 'r:UTF-8') do |file|
           
         file.each_line do |line|
           

--- a/lib/mysql2psql/postgres_file_writer.rb
+++ b/lib/mysql2psql/postgres_file_writer.rb
@@ -4,7 +4,7 @@ class Mysql2psql
 
 class PostgresFileWriter < PostgresWriter
   def initialize(file)
-    @f = File.open(file, "w+")
+    @f = File.open(file, "w+:UTF-8")
     @f << <<-EOF
 -- MySQL 2 PostgreSQL dump\n
 SET client_encoding = 'UTF8';

--- a/mysql-to-postgres.gemspec
+++ b/mysql-to-postgres.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
      "lib/mysql2psql/config.rb",
      "lib/mysql2psql/config_base.rb",
      "lib/mysql2psql/converter.rb",
+     "lib/mysql2psql/connection.rb",
      "lib/mysql2psql/errors.rb",
      "lib/mysql2psql/mysql_reader.rb",
      "lib/mysql2psql/postgres_db_writer.rb",


### PR DESCRIPTION
This fixes conversion errors when loading in mysql data that contains utf-8 characters
