### PR TITLE
Support for DDL migrations and repeated migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Sample Configuration file:
       username: terrapotamus
       password: default
       host: 127.0.0.1
-  
+
     development: &development
       <<: *default
       database: default_development
@@ -36,7 +36,7 @@ Sample Configuration file:
     mysql2psql:
       mysql:
         <<: *pii
-    
+
       destination:
         production:
           <<: *production
@@ -44,7 +44,7 @@ Sample Configuration file:
           <<: *test
         development:
           <<: *development
-      
+
       tables:
       - countries
       - samples
@@ -53,18 +53,23 @@ Sample Configuration file:
       - variables
       - sample_variables
 
-      # if suppress_data is true, only the schema definition will be exported/migrated, and not the data
+      # If suppress_data is true, only the schema definition will be exported/migrated, and not the data
       suppress_data: false
 
-      # if suppress_ddl is true, only the data will be exported/imported, and not the schema
+      # If suppress_ddl is true, only the data will be exported/imported, and not the schema
       suppress_ddl: true
 
-      # if force_truncate is true, forces a table truncate before table loading
+      # If force_truncate is true, forces a table truncate before table loading
       force_truncate: false
 
       preserve_order: true
 
       remove_dump_file: true
-  
+
+      dump_file_directory: /tmp
+
       report_status:  json    # false, json, xml
 
+      # If clear_schema is true, the public schema will be recreated before conversion
+      # The import will fail if both clear_schema and suppress_ddl are true.
+      clear_schema: false

--- a/config/default.database.yml
+++ b/config/default.database.yml
@@ -47,13 +47,13 @@ mysql2psql:
   - variables
   - sample_variables
 
-  # if suppress_data is true, only the schema definition will be exported/migrated, and not the data
+  # If suppress_data is true, only the schema definition will be exported/migrated, and not the data
   suppress_data: false
 
-  # if suppress_ddl is true, only the data will be exported/imported, and not the schema
+  # If suppress_ddl is true, only the data will be exported/imported, and not the schema
   suppress_ddl: true
 
-  # if force_truncate is true, forces a table truncate before table loading
+  # If force_truncate is true, forces a table truncate before table loading
   force_truncate: false
 
   preserve_order: true
@@ -63,3 +63,7 @@ mysql2psql:
   dump_file_directory: /tmp
   
   report_status:  json    # false, json, xml
+  
+  # If clear_schema is true, the public schema will be recreated before conversion
+  # The import will fail if both clear_schema and suppress_ddl are true.
+  clear_schema: false

--- a/lib/mysql2psql/converter.rb
+++ b/lib/mysql2psql/converter.rb
@@ -2,7 +2,7 @@ class Mysql2psql
 
   class Converter
     attr_reader :reader, :writer, :options
-    attr_reader :exclude_tables, :only_tables, :suppress_data, :suppress_ddl, :force_truncate, :preserve_order
+    attr_reader :exclude_tables, :only_tables, :suppress_data, :suppress_ddl, :force_truncate, :preserve_order, :clear_schema
   
     def initialize(reader, writer, options)
       @reader = reader
@@ -14,6 +14,7 @@ class Mysql2psql
       @suppress_ddl = options.suppress_ddl(false)
       @force_truncate = options.force_truncate(false)
       @preserve_order = options.preserve_order(false)
+      @clear_schema = options.clear_schema(false)
     end
   
     def convert
@@ -21,7 +22,7 @@ class Mysql2psql
       tables = reader.tables.
         reject {|table| @exclude_tables.include?(table.name)}.
         select {|table| @only_tables ? @only_tables.include?(table.name) : true}
-        
+
       if @preserve_order
 
         reordered_tables = []
@@ -32,38 +33,42 @@ class Mysql2psql
         end
 
         tables = reordered_tables
-        
+
       end
 
       tables.each do |table|
         writer.write_table(table)
       end unless @suppress_ddl
- 
+
       # tables.each do |table|
       #   writer.truncate(table) if force_truncate && suppress_ddl
       #   writer.write_contents(table, reader)
       # end unless @suppress_data
- 
+
       unless @suppress_data
-        
+
         tables.each do |table|
           writer.truncate(table) if force_truncate and suppress_ddl
         end
-        
+
         tables.each do |table|
           writer.write_contents(table, reader)
         end
-        
+
       end
- 
+
       tables.each do |table|
         writer.write_indexes(table)
       end unless @suppress_ddl
       tables.each do |table|
         writer.write_constraints(table)
       end unless @suppress_ddl
- 
+
       writer.close
+
+      if @clear_schema
+        writer.clear_schema
+      end
 
       writer.inload
 

--- a/lib/mysql2psql/postgres_db_writer.rb
+++ b/lib/mysql2psql/postgres_db_writer.rb
@@ -18,6 +18,10 @@ class Mysql2psql
       connection.load_file(path)    
     end
 
+    def clear_schema
+      connection.clear_schema
+    end
+
   end
 
 end


### PR DESCRIPTION
I've only tested this with JRuby, but with these changes I can do a full copy to an empty PostgeSQL database, run a bunch of Rails migrations on the PostgreSQL database, then run the copy from MySQL again.
