### PR TITLE
Do not hard-code MRI version in `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ platforms :jruby do
   gem 'activerecord-jdbcpostgresql-adapter'
 end
 
-platforms :mri_19 do
+platforms :mri do
   gem 'pg', '~> 0.17'
 end
 


### PR DESCRIPTION
As it pains and confuses people building `gem` from source. Prevents things like #74.