### PR TITLE
Unlock ruby version in Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ sudo: false
 language: ruby
 rvm:
   - "2.1.7"
-  - "2.2.3"
+  - "2.2.4"
+  - "2.3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
-ruby '2.1.7'
 source 'https://rubygems.org'
 
 gem 'rake', '~> 10.3'


### PR DESCRIPTION
Hi,

Here's a quick fix for a failing Travis build — since Bundler only supports fixed version matching for `ruby` specifying `2.1.7` does not allow using it on any other versions.

This PR removes this and adds ruby 2.3 as a testing target for Travis.